### PR TITLE
bug fix of lifter_controller_index

### DIFF
--- a/src/lifter_controller.h
+++ b/src/lifter_controller.h
@@ -56,6 +56,9 @@ private:
   float lifter_ratio_;
   bool update_joints,on_protective_stop;
 
+  int ankle_jnumber_,knee_jnumber_;
+  bool update_joints_once;
+
 };
 
 #endif


### PR DESCRIPTION
ゲームパッドの操作をしていない時に、joint_stateからankle_jointとknee_jointの現在値を取得していたが、
joint_stateの配列順がABC順なので、アームの場合は配列番号が一致していなかった。
そのため、下記のように修正。
* joint_stateをsubする際、１回目に配列番号を記憶する
* 2回目以降は、現在値をjoint_angles_に格納する